### PR TITLE
Tested and modified category picker

### DIFF
--- a/src/Components/CategoryPicker.js
+++ b/src/Components/CategoryPicker.js
@@ -6,33 +6,20 @@ import { collection, query, onSnapshot } from "firebase/firestore";
 export const CategoryPicker = ({category, setCategory, year, month}) => {
     useEffect(() => {
         const q = query(collection(db, "users", `${auth.currentUser.uid}`, "budgets", `${year}`, `${month}`));
-        onSnapshot(q, (snapshot) => {
-            const newItems = [];
-            snapshot.docChanges().forEach((change) => {
-                if (change.type === "added") {
-                    if (!items.some(object => object.label == change.data().category)) {
-                        console.log("read" + change.data().category)
-                        newItems.push(
-                            ... items,
-                            {label: change.data().category, value: change.data().category}
-                        ); 
-                    }
-                }
-                if (change.type === "removed") {
-                    newItems = [... items]
-                    if (snapshot.docs.filter(doc => doc.data().category == change.data().category) == 0) {
-                        newItems.filter(object => object.label == change.data().category);
-                    }
-                }
+        const unsubscribe = onSnapshot(q, (snapshot) => {  
+            const newItems = [{label: 'Others', value: 'Others'}];
+            snapshot.forEach((doc) => {
+                newItems.push(
+                    {label: doc.data().category, value: doc.data().category}
+                ); 
             })
             setItems(newItems);
         })
-    }, []);
+        return () => { unsubscribe(); }
+    }, [month, year]);
 
     const [open, setOpen] = useState(false);
-    const [items, setItems] = useState([
-        {label: 'Others', value: 'Others'}
-    ]);
+    const [items, setItems] = useState([]);
 
     return (
         <DropDownPicker

--- a/src/screens/BudgetScreen.js
+++ b/src/screens/BudgetScreen.js
@@ -17,7 +17,7 @@ import { query, collection, onSnapshot, addDoc, deleteDoc, doc, orderBy, runTran
 import { Item } from '../Components/Item';
 import { Platform } from 'react-native-web';
 import { MonthDropdown } from "../Components/MonthDropdown";
-import { YearPicker } from "../Components/YearPicker";
+// import { YearPicker } from "../Components/YearPicker";
 
 export const BudgetScreen = ({ navigation }) => {
 

--- a/src/screens/EditExpensesScreen.js
+++ b/src/screens/EditExpensesScreen.js
@@ -5,7 +5,7 @@ import { collection, addDoc } from "firebase/firestore";
 import { DatePicker } from "../Components/DatePicker";
 import { CategoryPicker } from "../Components/CategoryPicker";
 
-export const EditExpensesScreen = ({ navigation, year, month }) => {
+export const EditExpensesScreen = ({ navigation}) => {
     const [date, setDate] = useState(new Date());
     const formattedDate = `${date.getDate()}` + "/" + `${date.getMonth() + 1}` + "/" + `${date.getFullYear()}`;
     const [amount, setAmount] = useState(0);
@@ -45,8 +45,8 @@ export const EditExpensesScreen = ({ navigation, year, month }) => {
             <CategoryPicker 
                 category={category}
                 setCategory={setCategory}
-                year={year}
-                month={month}
+                year={date.getFullYear()}
+                month={date.getMonth() + 1}
             />
             <Pressable
                 style={styles.button}

--- a/src/screens/ExpensesScreen.js
+++ b/src/screens/ExpensesScreen.js
@@ -52,7 +52,7 @@ export const ExpensesScreen = ({ navigation }) => {
             <Pressable
                 style={styles.button}
                 onPress={() => { 
-                    navigation.navigate('Add Expenses', year, month);
+                    navigation.navigate('Add Expenses');
                 }}>
                 <Text style={{fontSize: 20}}>Add Expense</Text>
             </Pressable>


### PR DESCRIPTION
- Tested and modified the category picker by manually adding entries into Firestore
- Changed EditExpenseScreen: instead of reflecting category options from the month selected on the ExpensesScreen, the category picker reflects inputs from the month selected in the expense entry itself (so if the user is adding an expense for May although the expense screen is currently displaying June entries, the category options will be from May too and not June) 