### PR TITLE
Fixed Insights Screen Bug

### DIFF
--- a/src/Components/Archive/DisplayExpenses2.js
+++ b/src/Components/Archive/DisplayExpenses2.js
@@ -1,6 +1,6 @@
 import { SafeAreaView, Text, StyleSheet, TextInput, Pressable } from "react-native";
 import React, { useEffect, useState } from 'react';
-import { db, auth } from "../Firebase";
+import { db, auth } from "../../Firebase";
 import { collection, query, onSnapshot, where, runTransaction, getDocs, doc, getDoc, increment, updateDoc } from "firebase/firestore";
 
 export const DisplayExpenses = ({ year, month, category }) => {

--- a/src/Components/Archive/displayExpenses1.js
+++ b/src/Components/Archive/displayExpenses1.js
@@ -1,6 +1,6 @@
 import { SafeAreaView, Text, StyleSheet, TextInput, Pressable } from "react-native";
 import React, { useEffect, useState } from 'react';
-import { db, auth } from "../Firebase";
+import { db, auth } from "../../Firebase";
 import { collection, query, onSnapshot, where, runTransaction, getDocs, doc, getDoc, increment, updateDoc } from "firebase/firestore";
 
 export const displayExpenses = (year, month, category) => {

--- a/src/Components/Entries/BudgetEntry.js
+++ b/src/Components/Entries/BudgetEntry.js
@@ -1,7 +1,6 @@
 import { StyleSheet, Text, View, TouchableOpacity } from 'react-native';
 import React from 'react';
 import { MaterialIcons } from '@expo/vector-icons';
-import { DisplayExpenses } from '../DisplayExpenses';
 
 export const BudgetEntry = (props) => {
     const { data, year, onDelete } = props;
@@ -16,7 +15,7 @@ export const BudgetEntry = (props) => {
         <View style={[styles.container, styles.containerShadow]}>
             <Text style={styles.taskText}>{data.category}</Text>
             <Text style={styles.taskText}>Budget: {data.amount}</Text>
-            <DisplayExpenses year={year} month={data.date} category={data.category} />
+            <Text style={styles.taskText}>Spent: {data.expenses}</Text>
             <DeleteIcon />
         </View>
     );


### PR DESCRIPTION
Bug: Insights Screen is not rendered with the latest information unless that corresponding month's Budget Screen is currently rendered. 

Fix: Instead of listening for changes in expenses from the Budget Screen and updating, the expenses field (in budget entries) is updated when a new Expense entry is added (on the Add Expenses Screen). The Insights Screen now always has the latest "spent" information in every category no matter what other screens are currently rendered. 