### PR TITLE
Fixed Others category bug

### DIFF
--- a/src/Components/Pickers/CategoryPicker.js
+++ b/src/Components/Pickers/CategoryPicker.js
@@ -11,9 +11,11 @@ export const CategoryPicker = ({category, setCategory, year, month}) => {
         const unsubscribe = onSnapshot(q, (snapshot) => {  
             const newItems = [{label: 'Others', value: 'Others'}];
             snapshot.forEach((doc) => {
-                newItems.push(
+                if (doc.data().category != "Others") {
+                  newItems.push(
                     {label: doc.data().category, value: doc.data().category}
-                ); 
+                  ); 
+                }
             })
             setItems(newItems);
         })

--- a/src/screens/EditExpensesScreen.js
+++ b/src/screens/EditExpensesScreen.js
@@ -1,7 +1,7 @@
 import { SafeAreaView, Text, StyleSheet, TextInput, Pressable } from "react-native";
 import React, { useState } from 'react';
 import { db, auth } from "../Firebase";
-import { collection, addDoc, updateDoc, query, getDocs, where } from "firebase/firestore";
+import { collection, addDoc, updateDoc, query, getDocs, where, setDoc, doc } from "firebase/firestore";
 import { DatePicker } from "../Components/Pickers/DatePicker";
 import { CategoryPicker } from "../Components/Pickers/CategoryPicker";
 
@@ -25,6 +25,16 @@ export const EditExpensesScreen = ({ navigation}) => {
     
             const q = query(collection(db, "users", `${thisUserID}`, "budgets", `${date.getFullYear()}`, `${date.getMonth() + 1}`), where("category", "==", object.category));
             const querySnapshot = await getDocs(q);
+            
+            if (querySnapshot.empty) {
+                await addDoc(collection(db, "users", `${thisUserID}`, "budgets", `${date.getFullYear()}`, `${date.getMonth() + 1}`), {
+                    date: `${date.getMonth() + 1}`, 
+                    category: object.category,
+                    amount: 0, 
+                    expenses: parseInt(object.amount)
+                }); 
+            }
+
             querySnapshot.forEach(async (doc) => {
                  const newExpense = parseInt(doc.data().expenses) + parseInt(object.amount);
                  await updateDoc(doc.ref, { expenses: newExpense });


### PR DESCRIPTION
Bug: Expense entries into the Others category were not being rendered on the Insights Screen.

Fix: "Others" document will be automatically added into the budgets collection when the user _first_ adds an expense entry under the Others category. Subsequent expense additions will all be tabulated under that budgets Others document. The Insights Screen can now retrieve the total expense in the budgets Others document and render it properly. 