### PR TITLE
Allow users to edit Expense entries

### DIFF
--- a/App.js
+++ b/App.js
@@ -13,6 +13,7 @@ import { store } from './src/Store';
 import React, { useState } from 'react';
 import TreeScreen from './src/Screens/TreeScreen';
 import { SetDateScreen } from './src/Screens/SetDateScreen';
+import { ChangeExpensesScreen } from './src/Screens/ChangeExpenseScreen';
 
 export default App = () => {
   return (
@@ -102,6 +103,11 @@ const ExpensesNavigator = () => {
           <Stack.Screen
               name="Select Month and Year"
               component={SetDateScreen}
+              options={{ headerShown: false }}
+          />
+          <Stack.Screen
+              name="Change Expenses"
+              component={ChangeExpensesScreen}
               options={{ headerShown: false }}
           />
         </Stack.Navigator>

--- a/src/Components/Entries/ExpenseEntry.js
+++ b/src/Components/Entries/ExpenseEntry.js
@@ -1,6 +1,8 @@
-import { StyleSheet, Text, View, TouchableOpacity } from 'react-native';
+import { StyleSheet, Text, View, TouchableOpacity, Pressable } from 'react-native';
 import React from 'react';
 import { MaterialIcons } from '@expo/vector-icons';
+import { useNavigation } from '@react-navigation/native';
+import { monthName } from '../../Functions/monthName';
 
 export const ExpenseEntry = ({data, onDelete}) => {
     const DeleteIcon = () => (
@@ -9,20 +11,29 @@ export const ExpenseEntry = ({data, onDelete}) => {
         </TouchableOpacity>
     );
 
+    const navigation = useNavigation();
+
     return (
-        <View style={styles.container}>
+        <Pressable 
+            style={styles.container}
+            onPress={() => {
+                navigation.navigate("Change Expenses", {
+                    data: data
+                })
+            }}
+        >
             <View style={{flex: 3}}>
                 <Text style={styles.description}>{data.description}</Text>
                 <Text style={styles.category}>{data.category}</Text>
             </View>
             
             <View style={{flex: 1}}>
-                <Text style={styles.amount}>{data.amount}</Text>
-                <Text style={styles.date}>{data.date}</Text>
+                <Text style={styles.amount}>{"$" + data.amount.toFixed(2)}</Text>
+                <Text style={styles.date}>{data.date.split("/")[0] + " " + monthName(parseInt(data.date.split("/")[1]))}</Text>
             </View>
             
             <DeleteIcon /> 
-        </View>
+        </Pressable>
     );
 }
 

--- a/src/Components/Pickers/DatePicker.js
+++ b/src/Components/Pickers/DatePicker.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import DateTimePicker from '@react-native-community/datetimepicker';
 import { SafeAreaView, StyleSheet, Pressable, Text, View, ImageBackgroundComponent } from "react-native";
 
-export const DatePicker = ({date, setDate}) => {
+export const DatePicker = ({date, setDate, placeHolder}) => {
     const [toDisplay, setToDisplay] = useState(false);
 
     return (
@@ -11,7 +11,7 @@ export const DatePicker = ({date, setDate}) => {
                 style={styles.button}
                 onPress={() => setToDisplay(true)}
             >
-                <Text style={{fontSize: 20, color: "#a9a9a9"}}>Date</Text>
+                <Text style={{fontSize: 20, color: "#a9a9a9"}}>{placeHolder}</Text>
             </Pressable>
             { toDisplay && 
                 <DateTimePicker

--- a/src/screens/ChangeExpenseScreen.js
+++ b/src/screens/ChangeExpenseScreen.js
@@ -21,8 +21,6 @@ export const ChangeExpensesScreen = ({ navigation, route }) => {
 
     useEffect(() => {
         const arr = data.date.split("/");
-        console.log(data.date)
-        console.log(arr);
         const unformattedOgDate = new Date(arr[2], arr[1] - 1, arr[0]);
         setDate(unformattedOgDate);
         setDescription(data.description);

--- a/src/screens/ExpensesScreen.js
+++ b/src/screens/ExpensesScreen.js
@@ -25,9 +25,9 @@ export const ExpensesScreen = ({ navigation }) => {
                 if (doc.id != "Total") {
                     items.push({
                         id: doc.id,
-                        amount: "$" + doc.data().amount.toFixed(2),
+                        amount: doc.data().amount,
                         category: doc.data().category,
-                        date: doc.data().date.split("/")[0] + " " + monthName(parseInt(doc.data().date.split("/")[1])),
+                        date: doc.data().date,
                         description: doc.data().description
                     }); 
                 }


### PR DESCRIPTION
- New Edit Transaction Screen
- Users can click on previously-added expense entries to be directed to this screen with all entries pre-filled with the original input 
- The entry's document + total expenses document + affected budget categories' expenses (new and original) will be updated 